### PR TITLE
Исправление определения кнопок групповых операций

### DIFF
--- a/common/widgets/admin/Grid.php
+++ b/common/widgets/admin/Grid.php
@@ -259,7 +259,7 @@ class Grid extends Widget
     {
 
         if ($this->groupButtons !== null) {
-            return $this->$groupButtons;
+            return $this->groupButtons;
         } else {
             return $this->defaultGroupButtons();
         }


### PR DESCRIPTION
Исправление определения кнопок групповых операций в \common\widgets\admin\Grid
